### PR TITLE
don't look for /etc/resolv.conf on windows

### DIFF
--- a/pkg/vmsock/conn_windows.go
+++ b/pkg/vmsock/conn_windows.go
@@ -23,7 +23,7 @@ import (
 )
 
 func Listen() (net.Listener, error) {
-	vmGuid, err := vmGuid()
+	vmGUID, err := vmGUID()
 	if err != nil {
 		return nil, fmt.Errorf("Listen, could not determine VM GUID: %v", err)
 	}
@@ -33,7 +33,7 @@ func Listen() (net.Listener, error) {
 	}
 
 	addr := hvsock.Addr{
-		VMID:      vmGuid,
+		VMID:      vmGUID,
 		ServiceID: svcPort,
 	}
 


### PR DESCRIPTION
This could be misleading when the host process looks for `/etc/resolv.conf` on the windows and emits a log line that can be misleading. Also, we should set the fallback IPs if the upstream assignment fails. 

Signed-off-by: Nino Kodabande <nkodabande@suse.com>