### PR TITLE
golangci-lint: Exclude less of dns.go

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,3 @@
-run:
-  skip-files:
-    - pkg/dns/dns.go # don't lint upstream file, it will be removed soon
 linters-settings:
   dupl:
     threshold: 100
@@ -110,3 +107,13 @@ issues:
     - path: cmd/* #exclude cmd dir for gochecknoinits since it contains init funcs for cobra cli
       linters:
         - gochecknoinits
+    - # Allow overly-complex upstream file
+      path: pkg/dns/dns.go
+      linters:
+        - funlen
+        - gocyclo
+    - # Allow upstream code that doesn't conform
+      path: pkg/dns/dns.go
+      linters:
+        - gocritic
+      text: captLocal


### PR DESCRIPTION
While we have plans to remove that file at some point, that's not right now; so we should make the lint as strict as we can without having to deal with upstream issues we don't want to fix yet.